### PR TITLE
Make external cam provider ignore internal cam(01)

### DIFF
--- a/configs/external_camera_config.xml
+++ b/configs/external_camera_config.xml
@@ -1,0 +1,15 @@
+<ExternalCamera>
+    <Provider>
+        <!-- Internal video devices to be ignored by external camera HAL -->
+        <ignore>
+            <id>0</id>
+            <id>1</id>
+            <id>2</id>
+            <id>3</id>
+            <id>32</id>
+            <id>33</id>
+            <id>38</id>
+            <id>39</id>
+        </ignore>
+    </Provider>
+</ExternalCamera>


### PR DESCRIPTION
* The external camera provider occupies our camera v4l2 nodes,
  potentially crashing the kernel driver and blocking the camera HAL.
  Unfortunately, there's no easy way to just disable it, so let's just
  tell it to ignore the internal video devices.