### PR TITLE
Make external cam provider ignore internal cam(02)

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -180,6 +180,9 @@ PRODUCT_PACKAGES += \
     camera.msm8916 \
     Camera2
 
+PRODUCT_COPY_FILES += \
+    $(LOCAL_PATH)/configs/external_camera_config.xml:$(TARGET_COPY_OUT_VENDOR)/etc/external_camera_config.xml
+
 # Permissions
 PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.hardware.camera.flash-autofocus.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.camera.flash-autofocus.xml \


### PR DESCRIPTION
* The external camera provider occupies our camera v4l2 nodes,
  potentially crashing the kernel driver and blocking the camera HAL.
  Unfortunately, there's no easy way to just disable it, so let's just
  tell it to ignore the internal video devices.